### PR TITLE
Allow setting a Bearer token for user client requests

### DIFF
--- a/BearerClientTrait.php
+++ b/BearerClientTrait.php
@@ -1,0 +1,37 @@
+<?php
+namespace go1\clients;
+
+use go1\util\user\UserHelper;
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+
+trait BearerClientTrait
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    public function withBearerToken(string $token) : self
+    {
+        $retval = clone $this;
+        $retval->setBearerToken($token);
+        return $retval;
+    }
+
+    public function withRootJwt() : self
+    {
+        return $this->withBearerToken(UserHelper::ROOT_JWT);
+    }
+
+    private function setBearerToken(string $token)
+    {
+        $this->client = clone $this->client;
+        $this->client->__construct(array_merge_recursive(
+            $this->client->getConfig(),
+            [
+                RequestOptions::HEADERS => ['Authorization' => 'Bearer '.$token]
+            ]
+        ));
+    }
+}

--- a/UserClient.php
+++ b/UserClient.php
@@ -10,6 +10,8 @@ use stdClass;
 
 class UserClient
 {
+    use BearerClientTrait;
+
     private $client;
     private $userUrl;
     private $mqClient;
@@ -123,8 +125,21 @@ class UserClient
         return $this->findUsers($portalName, ['administrator'], $all, $limit, $offset);
     }
 
-    public function uuid2jwt(Client $client, string $userUrl, string $uuid, string $portalName = null)
+    /**
+     * @param string      $uuid
+     * @param string|null $portalName
+     * @return string|bool
+     */
+    public function uuid2jwt($uuid, string $portalName = null)
     {
+        //Backwards compatible signature
+        if ($uuid instanceof Client) {
+            [$client, $userUrl, $uuid, $portalName] = func_get_args();
+        } else {
+            $client = $this->client;
+            $userUrl = $this->userUrl;
+        }
+
         $url = rtrim($userUrl, '/') . "/account/current/{$uuid}" . (!is_null($portalName) ? "/{$portalName}" : '');
         $res = $client->get($url, ['http_errors' => false]);
 
@@ -133,8 +148,21 @@ class UserClient
             : false;
     }
 
-    public function profileId2jwt(Client $client, string $userUrl, int $profileId, string $portalName = null)
+    /**
+     * @param int         $profileId
+     * @param string|null $portalName
+     * @return bool|string
+     */
+    public function profileId2jwt($profileId, string $portalName = null)
     {
+        //Backwards compatible signature
+        if ($profileId instanceof Client) {
+            [$client, $userUrl, $profileId, $portalName] = func_get_args();
+        } else {
+            $client = $this->client;
+            $userUrl = $this->userUrl;
+        }
+
         return ($uuid = (new UserHelper())->profileId2uuid($client, $userUrl, $profileId))
             ? $this->uuid2jwt($client, $userUrl, $uuid, $portalName)
             : false;

--- a/tests/BearerClientStub.php
+++ b/tests/BearerClientStub.php
@@ -1,0 +1,20 @@
+<?php
+namespace go1\clients\tests;
+
+use go1\clients\BearerClientTrait;
+use GuzzleHttp\Client;
+
+class BearerClientStub
+{
+    use BearerClientTrait;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function getClient()
+    {
+        return $this->client;
+    }
+}

--- a/tests/BearerClientTraitTest.php
+++ b/tests/BearerClientTraitTest.php
@@ -1,0 +1,34 @@
+<?php
+namespace go1\clients\tests;
+
+use go1\util\user\UserHelper;
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\TestCase;
+
+class BearerClientTraitTest extends TestCase
+{
+    private $client;
+
+    private $testSubject;
+
+    protected function setUp() : void
+    {
+        $this->client = new Client([RequestOptions::HTTP_ERRORS => false]);
+        $this->testSubject = new BearerClientStub($this->client);
+    }
+
+    public function testWithBearerToken()
+    {
+        $testSubjectWithRootJwt = $this->testSubject->withRootJwt();
+
+        $initialClient = $this->testSubject->getClient();
+        $finalClient = $testSubjectWithRootJwt->getClient();
+        $this->assertNotSame($finalClient, $initialClient);
+
+        $headers = $finalClient->getConfig(RequestOptions::HEADERS);
+        $this->assertArrayHasKey('Authorization', $headers);
+        $this->assertEquals('Bearer '.UserHelper::ROOT_JWT, $headers['Authorization']);
+        $this->assertFalse($finalClient->getConfig(RequestOptions::HTTP_ERRORS));
+    }
+}


### PR DESCRIPTION
This allows setting the Authorization header for an instance of UserClient at runtime.
Also simplified a couple method's signature.